### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Unbundle OpenAPI MCP Server
 [![smithery badge](https://smithery.ai/badge/@auto-browse/unbundle_openapi_mcp)](https://smithery.ai/server/@auto-browse/unbundle_openapi_mcp)
 
+<a href="https://glama.ai/mcp/servers/@auto-browse/unbundle_openapi_mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@auto-browse/unbundle_openapi_mcp/badge" alt="Unbundle OpenAPI Specs MCP server" />
+</a>
+
 This project provides a Model Context Protocol (MCP) server with tools to split OpenAPI specification files into multiple files or extract specific endpoints into a new file. It allows an MCP client (like an AI assistant) to manipulate OpenAPI specifications programmatically.
 
 ## Prerequisites


### PR DESCRIPTION
This PR adds a badge for the [Unbundle OpenAPI Specs MCP](https://glama.ai/mcp/servers/@auto-browse/unbundle_openapi_mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@auto-browse/unbundle_openapi_mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@auto-browse/unbundle_openapi_mcp/badge" alt="Unbundle OpenAPI Specs MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.